### PR TITLE
add @babel/preset-env in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
     "@babel/preset-typescript": "^7.3.3",
+    "@babel/preset-env": "7.5.0",
     "@types/jest": "^24.0.15",
     "babel-jest": "^24.8.0",
     "cross-env": "^5.2.0",


### PR DESCRIPTION

PS E:\fre> yarn
yarn install v1.17.3
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.8: The platform "win32" is incompatible with this module.
info "fsevents@1.2.8" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 16.52s.
PS E:\fre> yarn test
yarn run v1.17.3
$ jest && tsc --noEmit
 FAIL  test/index.test.ts
  ● Test suite failed to run

    Cannot find module '@babel/preset-env' from 'E:\fre'
