### PR TITLE
Improve compatibility of `children` with React

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -8,8 +8,6 @@ export function h (type, config) {
     if (vnode == null || vnode === true || vnode === false) {
     } else if (Array.isArray(vnode) || typeof vnode === 'object') {
       children.push(vnode)
-    } else if (typeof vnode === 'function') {
-      children = vnode
     } else {
       children.push({ type: 'text', props: { nodeValue: vnode } })
     }
@@ -17,7 +15,11 @@ export function h (type, config) {
 
   delete props.key
 
-  props.children = children
+  if (children.length) {
+    props.children = children.length === 1
+      ? children[0]
+      : children
+  }
 
   return { type, props, key }
 }

--- a/src/h.test.jsx
+++ b/src/h.test.jsx
@@ -8,9 +8,7 @@ test('create JSX node', () => {
   expect(div).toStrictEqual({
     type: "div",
     key: null,
-    props: {
-      children: []
-    }
+    props: {}
   })
 })
 
@@ -22,8 +20,7 @@ test('create JSX node with key and props', () => {
     key: "foo",
     props: {
       name: "foo",
-      value: "bar",
-      children: []
+      value: "bar"
     }
   })
 })
@@ -41,23 +38,17 @@ test('create JSX node with children', () => {
     type: "div",
     key: "a",
     props: {
-      children: [
-        {
-          type: "div",
-          key: "b",
-          props: {
-            children: [
-              {
-                type: "div",
-                key: "c",
-                props: {
-                  children: []
-                }
-              }
-            ]
+      children: {
+        type: "div",
+        key: "b",
+        props: {
+          children: {
+            type: "div",
+            key: "c",
+            props: {}
           }
         }
-      ]
+      }
     }
   })
 })
@@ -68,9 +59,7 @@ test('ignore `true`, `false`, `null` and `undefined` JSX literals', () => {
   expect(div).toStrictEqual({
     type: "div",
     key: null,
-    props: {
-      children: []
-    }
+    props: {}
   })
 })
 
@@ -100,9 +89,10 @@ test('emit JSX component nodes', () => {
     key: null,
     props: {
       value: "foo",
-      children: [
-        { type: "text", props: { nodeValue: "bar" } },
-      ]
+      children: {
+        type: "text",
+        props: { nodeValue: "bar" }
+      }
     }
   })
 })


### PR DESCRIPTION
This PR updates the tests and code to improve compatibility of `children` with React:

1. JSX nodes with no children have no `children` property.
2. Multiple JSX child nodes/literals get wrapped in an array.
3. Single child nodes/literals do *not* get wrapped in an array.

Here's an example of the JSX nodes/literals emitted by React for the cases covered by this PR:

![image](https://user-images.githubusercontent.com/103348/65591710-430fc300-df8d-11e9-8378-81634f8d9312.png)

You've already said you don't need to be fully compatible with React, but the code as it was does contain a somewhat dangerous bug, as a function was actually able to erase other children - for example, `<Component>{function1}{function2}</Component>` would erase the first function, `<Component><div/>{function}</Component>` would erase the `<div>` element, and so on.

People often do things like `if (children)` to check if there are any children - as, as you pointed out, they do things like `children()` and expect a render-child to be invoked, so...

In my opinion, either the behavior of `children` should be identical to React (as per this PR) or no special handling of children should be done at all - trying to do something in between (risky handling on render-child) probably isn't a good idea.

On the up side, your `arrayify` function was already prepared for all of these edge-cases - reconciliation already seems to work nicely without having to change anything else, as you're already handling both the single-child and `undefined` children cases, so merging this change might not be a big deal?

It's hard for me to exactly recommend either one approach or the other - both have pros and cons.

Before you decide, also take a look at the [`React.Children`](https://reactjs.org/docs/react-api.html#reactchildren) API and consider how much more complexity these subtleties in React can cause in the long term. If you merge this, you may need this entire API as well.

It's a tough call. 🤔