### PR TITLE
JSX props map to object properties

### DIFF
--- a/demo/svg.js
+++ b/demo/svg.js
@@ -4,7 +4,7 @@ function App () {
   const [flag, setFlag] = useState(true)
   return (
     <div style={flag? { color: 'red' } : { backgroundColor: 'black' }}>
-      <svg xmlns='http://www.w3.org/2000/svg' version='1.1'>
+      <svg>
         <circle
           cx='100'
           cy='50'

--- a/src/dom.js
+++ b/src/dom.js
@@ -9,6 +9,8 @@ function updateProperty (dom, name, value, newValue) {
     name = name.slice(2).toLowerCase()
     if (value) dom.removeEventListener(name, value)
     dom.addEventListener(name, newValue)
+  } else if ((name in dom) && !(dom instanceof SVGElement)) {
+    dom[name] = newValue==null ? '' : newValue;
   } else if (newValue == null || newValue === false) {
     dom.removeAttribute(name)
   } else {
@@ -19,11 +21,7 @@ function updateProperty (dom, name, value, newValue) {
 export function updateElement (dom, props, newProps) {
   Object.keys(newProps)
     .filter(isNew(props, newProps))
-    .forEach(key => {
-      key === 'value' || key === 'nodeValue'
-        ? (dom[key] = newProps[key])
-        : updateProperty(dom, key, props[key], newProps[key])
-    })
+    .forEach(key => updateProperty(dom, key, props[key], newProps[key]));
 }
 
 export function createElement (fiber) {


### PR DESCRIPTION
JSX props map to object properties by default and falls back to attributes - except for SVG elements, which always use attributes.

Closes #46 

I will add some inline notes to the PR in a moment.
