### PR TITLE
choose `MessageChannel` or `setTimeout` at initialization

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -78,16 +78,20 @@ function performWork () {
   } else inMC = false
 }
 
-function planWork () {
-  port ? port.postMessage(null) : setTimeout(performWork, 0)
-}
+const planWork = (() => {
+  if (typeof MessageChannel !== "undefined") {
+    const channel = new MessageChannel()
+    const port = channel.port2
+    channel.port1.onmessage = performWork
+
+    return () => port.postMessage(null)
+  }
+
+  return () => setTimeout(performWork, 0)
+})()
 
 export function shouldYeild () {
   return getTime() > frameDeadline
 }
 
 const getTime = () => performance.now()
-
-const channel = new MessageChannel()
-const port = channel.port2
-channel.port1.onmessage = performWork

--- a/test/reconciler.test.jsx
+++ b/test/reconciler.test.jsx
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import { render } from "../src/reconciler"
+import { h } from "../src/h";
+
+const testRender = jsx => new Promise(resolve => {
+  let target = document.createElement("div")
+
+  document.body.appendChild(target)
+
+  render(jsx, target)
+
+  // TODO add callback to render function, e.g.:
+  //   render(jsx, target, () => resolve(target.innerHTML))
+  //   remove timeout hack below:
+  setTimeout(() => resolve(target.innerHTML), 100)
+})
+
+test('render HTML elements', done => {
+  testRender(<div>test</div>).then(html => {
+    expect(html).toBe("<div>test</div>")
+
+    done()
+  })
+})


### PR DESCRIPTION
While adding this preliminary test-setup for the reconciler, I discovered the feature-detection for `MessageChannel` wasn't working - it didn't work under node. This fixes that.

I left the preliminary test-setup in there - it's not much of a test yet, but at least provides that falling back to `setTimeout` works.
