### PR TITLE
debug `options.resolve` and add a few basic tests

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -147,7 +147,7 @@ function commitWork (WIP) {
     const e = p.effects
     if (e) for (const k in e) e[k]()
   })
-  if (options.resolve) resolve()
+  if (options.resolve) options.resolve()
   nextWork = pendingCommit = null
 }
 function commit (fiber) {


### PR DESCRIPTION
I fixed `options.resolve` and added a few basic tests.

It's enough to support writing some tests now, but I think we should keep #45 open - the approach with a global callback in `options` is really fragile, and I'm actually surprised that this works... if, for example, jest was to launch the tests in parallel, or if I tried to do multiple calls to `testRender` from within the same test, one test might wipe out the DOM (`document.body.innerHTML = ""`) while another test is trying to populate it.

Similarly, a real-world application that needs to render two component roots (two consecutive calls to `render` for two parts of an application) would likely cause problems.

It seems to work though, so we can revisit those issues later.
