### PR TITLE
remove `options.resolve` and add `render`-callback instead

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -9,11 +9,12 @@ let nextWork = null
 let pendingCommit = null
 let currentFiber = null
 
-function render (vnode, node) {
+function render (vnode, node, done) {
   let rootFiber = {
     tag: ROOT,
     node,
-    props: { children: vnode }
+    props: { children: vnode },
+    done
   }
   scheduleWork(rootFiber)
 }
@@ -64,7 +65,7 @@ function updateHost (WIP) {
 
 function getParentNode (fiber) {
   if (!fiber.parent) return fiber.node
-  while (fiber.parent.tag === HOOK) return fiber.parent.parent.node
+  if (fiber.parent.tag === HOOK) return fiber.parent.parent.node
   return fiber.parent.node
 }
 
@@ -147,7 +148,7 @@ function commitWork (WIP) {
     const e = p.effects
     if (e) for (const k in e) e[k]()
   })
-  if (options.resolve) options.resolve()
+  WIP.done && WIP.done()
   nextWork = pendingCommit = null
 }
 function commit (fiber) {

--- a/test/reconciler.test.jsx
+++ b/test/reconciler.test.jsx
@@ -1,12 +1,12 @@
 /** @jsx h */
 
-import { render, options } from "../src/reconciler"
+import { render } from "../src/reconciler"
 import { h } from "../src/h";
 
 const testRender = jsx => new Promise(resolve => {
   document.body.innerHTML = ""
 
-  options.resolve = () => {
+  render(jsx, document.body, () => {
     const html = document.createDocumentFragment();
 
     for (const child of document.body.childNodes) {
@@ -14,9 +14,7 @@ const testRender = jsx => new Promise(resolve => {
     }
 
     resolve(html)
-  }
-
-  render(jsx, document.body)
+  })
 })
 
 const toString = el => Array.from(el.childNodes).map(child => child.outerHTML).join("")


### PR DESCRIPTION
As asked in #55, let's drop `options.resolve` and add the `render`-callback instead, like React.

Instead of passing it through many functions, I simply attached the `done` callback to the fiber itself - and then check for the `done`-callback in `commitWork` at the end, and call it.

Does this seem correct to you?

The test is passing, so hopefully this was as easy as it appears to be? 🙂
