### PR TITLE
add `format` script using `standard`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "dist/fre-esm.js",
   "scripts": {
     "test": "jest --coverage",
-    "build": "rollup -c && gzip-size dist/fre.js"
+    "build": "rollup -c && gzip-size dist/fre.js",
+    "format": "standard --fix 'src/**/*.js'"
   },
   "keywords": [],
   "author": "132yse",
@@ -29,6 +30,7 @@
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-license": "^0.8.1",
     "rollup-plugin-terser": "^5.1.2",
+    "standard": "^14.3.1",
     "terser": "^4.1.2",
     "typescript": "^3.5.2",
     "yarpm": "^0.2.1"

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,3 +1,5 @@
+/* global SVGElement */
+
 import { SVG } from './reconciler'
 
 export function updateElement (dom, oldProps, newProps) {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,3 +1,5 @@
+/* global MessageChannel, performance */
+
 import { push, pop, peek } from './heapify'
 
 let taskQueue = []


### PR DESCRIPTION
What do you think about using [standard](https://standardjs.com/index.html) to format the code?

I tried `prettier` and `eslint` before this, but `standard` seems to match your code style by 95%.

I didn't commit the actual changes - this way, you can try it and diff locally to see if you agree with the changes. (It mostly just adds `const` where possible.)

It currently emits a few inspections:

```
  /mnt/c/workspace/fre/src/dom.js:10:18: Expected '===' and instead saw '=='.
  /mnt/c/workspace/fre/src/dom.js:14:35: Unexpected mix of '&&' and '||'.
  /mnt/c/workspace/fre/src/dom.js:14:50: Unexpected mix of '&&' and '||'.
  /mnt/c/workspace/fre/src/reconciler.js:44:11: Expected '===' and instead saw '=='.
```

I didn't want to fix any of these as part of this PR, as it might break things - we might want to wait and fix these after we have full test-coverage.
