### PR TITLE
Test effects

### DIFF
--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -153,28 +153,24 @@ test('useEffect(f, [x]) should run on changes to x', async () => {
   }
 
   await testUpdates([
-    // mounted: should trigger effect
     {
       content: <Component value={1}/>,
       test: () => {
         expect(effects).toEqual(["effect 1"])
       }
     },
-    // updated: should trigger effect
     {
       content: <Component value={2}/>,
       test: () => {
         expect(effects).toEqual(["cleanUp 1", "effect 2"])
       }
     },
-    // no change: should NOT trigger effect
     {
       content: <Component value={2}/>,
       test: () => {
         expect(effects).toEqual([])
       }
     },
-    // removal: should trigger clean-up
     {
       content: <div>removed</div>,
       test: () => {
@@ -204,25 +200,66 @@ test('useEffect(f, []) should run only once', async () => {
   }
 
   await testUpdates([
-    // mounted: should trigger effect
     {
       content: <Component/>,
       test: () => {
         expect(effects).toEqual(['effect'])
       }
     },
-    // updated: should NOT trigger effect
     {
       content: <Component/>,
       test: () => {
         expect(effects).toEqual([])
       }
     },
-    // removal: should trigger clean-up
     {
       content: <div>removed</div>,
       test: () => {
         expect(effects).toEqual(['cleanUp'])
+      }
+    }
+  ])
+})
+
+test('useEffect(f) should run every time', async () => {
+  let effects = []
+  let effectNum = 1
+
+  const effect = () => {
+    const currentEffectNum = effectNum++
+
+    effects.push(`effect ${currentEffectNum}`)
+
+    return () => {
+      effects.push(`cleanUp ${currentEffectNum}`)
+    }
+  }
+
+  const Component = () => {
+    effects = []
+
+    useEffect(effect)
+
+    return <div>foo</div>
+  }
+
+  await testUpdates([
+    {
+      content: <Component/>,
+      test: () => {
+        expect(effects).toEqual(["effect 1"])
+      }
+    },
+    {
+      content: <Component/>,
+      test: () => {
+        expect(effects).toEqual(["cleanUp 1", "effect 2"])
+      }
+    },
+    {
+      content: <div>removed</div>,
+      test: () => {
+        expect(effects).toEqual(["cleanUp 2"])
       }
     }
   ])

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -133,25 +133,21 @@ test('attach/remove DOM event handler', async () => {
   ])
 })
 
-test('useEffect(f, [x]) should detect changes to x', async () => {
-  let effects = 0
-  let cleanUps = 0
+test('useEffect(f, [x]) should run on changes to x', async () => {
+  let effects = []
 
-  const cleanUp = () => {
-    cleanUps += 1
-  }
+  const effect = value => {
+    effects.push(`effect ${value}`)
 
-  const effect = () => {
-    effects += 1
-
-    return cleanUp
+    return () => {
+      effects.push(`cleanUp ${value}`)
+    }
   }
 
   const Component = ({ value }) => {
-    effects = 0
-    cleanUps = 0
+    effects = []
 
-    useEffect(effect, [value])
+    useEffect(() => effect(value), [value])
 
     return <div>foo</div>
   }
@@ -161,32 +157,28 @@ test('useEffect(f, [x]) should detect changes to x', async () => {
     {
       content: <Component value={1}/>,
       test: () => {
-        expect(effects).toBe(1)
-        expect(cleanUps).toBe(0)
+        expect(effects).toEqual(["effect 1"])
       }
     },
     // updated: should trigger effect
     {
       content: <Component value={2}/>,
       test: () => {
-        expect(effects).toBe(1)
-        expect(cleanUps).toBe(1)
+        expect(effects).toEqual(["cleanUp 1", "effect 2"])
       }
     },
     // no change: should NOT trigger effect
     {
       content: <Component value={2}/>,
       test: () => {
-        expect(effects).toBe(0)
-        expect(cleanUps).toBe(0)
+        expect(effects).toEqual([])
       }
     },
     // removal: should trigger clean-up
     {
       content: <div>removed</div>,
       test: () => {
-        expect(effects).toBe(0)
-        expect(cleanUps).toBe(1)
+        expect(effects).toEqual(["cleanUp 2"])
       }
     }
   ])

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -184,6 +184,50 @@ test('useEffect(f, [x]) should run on changes to x', async () => {
   ])
 })
 
+test('useEffect(f, []) should run only once', async () => {
+  let effects = []
+
+  const effect = () => {
+    effects.push('effect')
+
+    return () => {
+      effects.push('cleanUp')
+    }
+  }
+
+  const Component = () => {
+    effects = []
+
+    useEffect(effect, [])
+
+    return <div>foo</div>
+  }
+
+  await testUpdates([
+    // mounted: should trigger effect
+    {
+      content: <Component/>,
+      test: () => {
+        expect(effects).toEqual(['effect'])
+      }
+    },
+    // updated: should NOT trigger effect
+    {
+      content: <Component/>,
+      test: () => {
+        expect(effects).toEqual([])
+      }
+    },
+    // removal: should trigger clean-up
+    {
+      content: <div>removed</div>,
+      test: () => {
+        expect(effects).toEqual(['cleanUp'])
+      }
+    }
+  ])
+})
+
 test('obtain reference to DOM element', async () => {
   const ref = useRef()
 


### PR DESCRIPTION
Alright, here's a failing test that should demonstrate the problem we discussed in #79 .

As you can see, we're good on `useEffect(f, [x])` as well as `useEffect(f, [])`. 👍

The problem is with `useEffect(f)` which seems to trigger some effects and cleanups *twice* -

```jsx
test('useEffect(f) should run every time', async () => {
  let effects = []
  let effectNum = 1

  const effect = () => {
    const currentEffectNum = effectNum++

    effects.push(`effect ${currentEffectNum}`)

    return () => {
      effects.push(`cleanUp ${currentEffectNum}`)
    }
  }

  const Component = () => {
    effects = []

    useEffect(effect)

    return <div>foo</div>
  }

  await testUpdates([
    {
      content: <Component/>,
      test: () => {
        expect(effects).toEqual(["effect 1"])
      }
    },
    {
      content: <Component/>,
      test: () => {
        expect(effects).toEqual(["cleanUp 1", "effect 2"]) 👍
      }
    },
    {
      content: <div>removed</div>,
      test: () => {
        expect(effects).toEqual(["cleanUp 2"]) 👎 /* LINE 262 */
      }
    }
  ])
})
```

As you will see when running the test:

```
    - Expected
    + Received
    
      Array [
    +   "cleanUp 1",
    +   "effect 2",
        "cleanUp 2",
      ]
        at Object.toEqual [as test] (/mnt/c/workspace/fre/test/render.test.jsx:262:25)
```

So, at removal, `cleanUp 1` and `effect 2` are currently both being run a second time!

Note that I did already merge your [last commit](https://github.com/132yse/fre/commit/ec5c1f0ac4aae37b1ad0f004a8fefc8423d4d167) which didn't fix it.

Hopefully this will help you fix it 😊