### PR TITLE
Fix confusing test

### DIFF
--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -236,8 +236,6 @@ test('useEffect(f) should run every time', async () => {
   }
 
   const Component = () => {
-    effects = []
-
     useEffect(effect)
 
     return <div>foo</div>
@@ -248,18 +246,22 @@ test('useEffect(f) should run every time', async () => {
       content: <Component/>,
       test: () => {
         expect(effects).toEqual(["effect 1"])
+
+        effects = []
       }
     },
     {
       content: <Component/>,
       test: () => {
         expect(effects).toEqual(["cleanUp 1", "effect 2"])
+
+        effects = []
       }
     },
     {
       content: <div>removed</div>,
       test: () => {
-        expect(effects).toEqual(["cleanUp 1", "effect 2", "cleanUp 2"])
+        expect(effects).toEqual(["cleanUp 2"])
       }
     }
   ])


### PR DESCRIPTION
> clearing `effects` from within `Component` doesn't happen when the component instance gets destroyed! this made it look like effects and clean-up from the previous update-step were executing twice. I fixed this by manually clearing `effects` after the assertions in each step.

Now the test makes sense 😄

Closes #79 🎉