### PR TITLE
add support for references to any value with `useRef`

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -52,7 +52,7 @@ export function useCallback (cb, deps) {
 }
 
 export function useRef (current) {
-  return { current }
+  return useMemo(() => ({ current }), [])
 }
 
 function isChanged (a, b) {

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -287,6 +287,33 @@ test('obtain reference to DOM element', async () => {
   expect(ref.current).toBe(elements[0])
 })
 
+test('persist reference to any value', async () => {
+  const Component = () => {
+    const ref = useRef("")
+
+    ref.current = ref.current + "x"
+
+    return <p>{ref.current}</p>
+  }
+
+  const content = <Component/>
+
+  await testUpdates([
+    {
+      content,
+      test: ([p]) => {
+        expect(p.textContent).toBe("x")
+      }
+    },
+    {
+      content,
+      test: ([p]) => {
+        expect(p.textContent).toBe("xx")
+      }
+    }
+  ])
+})
+
 test('reorder and reuse elements during key-based reconciliation of child-nodes', async () => {
   const states = [
     [1, 2, 3],


### PR DESCRIPTION
Allows using refs for other things besides DOM elements.

References [Preact's implementation](https://github.com/preactjs/preact/blob/f0fa29455527cd6fd9abe8296c5a18d4ecd5f262/hooks/src/index.js#L140).

Comes with a test that failed before this change.

(see also [React docs](https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables))
