### PR TITLE
Replace element with text-node

### DIFF
--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -116,6 +116,12 @@ test('render/update object properties and DOM attributes', async () => {
 
         lastChildren.forEach((lastChild, index) => expect(elements[0].children[index]).toBe(lastChild))
       }
+    },
+    {
+      content: "removed",
+      test: ([text]) => {
+        expect(text.textContent).toBe("removed")
+      }
     }
   ])
 })


### PR DESCRIPTION
This PR adds a regression test for an edge-case: replacing an element with a text-node during an update causes a crash in the reconciler.
