### PR TITLE
Implemention of memo into fre core.

### DIFF
--- a/demo/context.js
+++ b/demo/context.js
@@ -32,15 +32,15 @@ export function createContext(defaultValue) {
 const useTheme = createContext('light')
 
 function App() {
-  console.log(111)
   const [theme, setTheme] = useTheme()
+  const setMemoTheme = useCallback(() =>
+    setTheme(theme === 'dark' ? 'light' : 'dark')
+  )
   return (
     <div>
       {theme}
       <A />
-      <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
-        change
-      </button>
+      <button onClick={setMemoTheme}>change</button>
     </div>
   )
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <div id="root"></div>
-  <script src="context.js"></script>
+  <script src="useEffect.js"></script>
 </body>
 
 </html>

--- a/demo/useState.js
+++ b/demo/useState.js
@@ -1,10 +1,10 @@
-import { h, render, useState, useEffect } from '../src'
+import { h, render, useState } from '../src'
 
 function App () {
   const [state, setState] = useState(0)
-  console.log(111)
   return (
     <div>
+      {state}
       <A count={1}/>
       <button onClick={() => setState(state+1)}>+</button>
     </div>

--- a/src/h.js
+++ b/src/h.js
@@ -1,9 +1,7 @@
-let oldProps = null
 export function h(type, attrs) {
   let props = attrs || {}
   let key = props.key || null
   let ref = props.ref || null
-  let compare = false
   let children = []
 
   for (let i = 2; i < arguments.length; i++) {
@@ -23,7 +21,7 @@ export function h(type, attrs) {
   delete props.key
   delete props.ref
 
-  return { type, props, key, ref, compare }
+  return { type, props, key, ref }
 }
 
 export function createText(vnode) {

--- a/src/h.js
+++ b/src/h.js
@@ -1,7 +1,9 @@
-export function h (type, attrs) {
+let oldProps = null
+export function h(type, attrs) {
   let props = attrs || {}
   let key = props.key || null
   let ref = props.ref || null
+  let compare = false
   let children = []
 
   for (let i = 2; i < arguments.length; i++) {
@@ -20,9 +22,10 @@ export function h (type, attrs) {
 
   delete props.key
   delete props.ref
-  return { type, props, key, ref }
+
+  return { type, props, key, ref, compare }
 }
 
-export function createText(vnode){
+export function createText(vnode) {
   return { type: 'text', props: { nodeValue: vnode } }
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -13,7 +13,7 @@ export function useReducer(reducer, initState) {
   const hook = getHook(cursor++)
   const current = getCurrentHook()
 
-  const setter = useCallback(value => {
+  const setter = value => {
     let newValue = reducer
       ? reducer(hook[0], value)
       : isFn(value)
@@ -21,7 +21,7 @@ export function useReducer(reducer, initState) {
       : value
     hook[0] = newValue
     scheduleWork(current, true)
-  }, [])
+  }
 
   if (hook.length) {
     return [hook[0], setter]

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -78,13 +78,12 @@ function reconcile(WIP) {
 function updateHOOK(WIP) {
   const oldProps = WIP.pendingProps
   let newProps = WIP.props
-  currentFiber = WIP
-  resetCursor()
   if (WIP.lock === null && !shouldUpdate(oldProps, newProps)) {
-    console.log(WIP,oldProps,newProps)
     cloneChildren(WIP)
     return
   }
+  currentFiber = WIP
+  resetCursor()
   let children = WIP.type(newProps)
   if (!children.type) {
     children = createText(children)

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -11,7 +11,6 @@ let currentFiber = options.currentFiber || null
 let WIP = null
 let updateQueue = []
 let commitQueue = []
-const EMPTY_OBJ = {}
 
 export function render(vnode, node, done) {
   let rootFiber = {
@@ -61,6 +60,7 @@ function reconcileWork(didout) {
 function reconcile(WIP) {
   WIP.parentNode = getParentNode(WIP)
   WIP.tag == HOOK ? updateHOOK(WIP) : updateHost(WIP)
+  WIP.alter = WIP
   commitQueue.push(WIP)
 
   if (WIP.child) return WIP.child
@@ -76,15 +76,19 @@ function reconcile(WIP) {
 }
 
 function updateHOOK(WIP) {
-  WIP.props = WIP.props || EMPTY_OBJ
+  const oldProps = (WIP.alter || {}).props
+  let newProps = WIP.props
   currentFiber = WIP
   resetCursor()
-  let children = WIP.type(WIP.props)
+  if (WIP.lock === null && !shouldUpdate(oldProps, newProps)) {
+    cloneChildren(WIP)
+    return
+  }
+  let children = WIP.type(newProps)
   if (!children.type) {
     children = createText(children)
   }
   reconcileChildren(WIP, children)
-  return WIP
 }
 
 function updateHost(WIP) {
@@ -160,6 +164,29 @@ function reconcileChildren(WIP, children) {
   WIP.lock = WIP.lock ? false : null
 }
 
+function cloneChildren(fiber) {
+  if (!fiber.child) return
+
+  let currentChild = fiber.child
+  let newChild = currentChild
+  fiber.child = newChild
+  newChild.parent = fiber
+
+  while (currentChild.sibling) {
+    currentChild = currentChild.sibling
+    newChild = newChild.sibling = currentChild
+    newChild.parent = fiber
+  }
+
+  newChild.sibling = null
+}
+
+function shouldUpdate(a, b) {
+  for (let i in a) if (!(i in b)) return true
+  for (let i in b) if (a[i] !== b[i]) return true
+  return false
+}
+
 function shouldPlace(fiber) {
   let p = fiber.parent
   if (p.tag === HOOK) return p.key && !p.lock
@@ -172,7 +199,6 @@ function commitWork(fiber) {
   })
   fiber.done && fiber.done()
   commitQueue = []
-  // updateQueue = []
   preCommit = null
   WIP = null
 }

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -289,14 +289,14 @@ test('useEffect(f) should run every time', async () => {
       content: <Component />,
       test: () => {
         nextTick()
-        expect(effects).toEqual(['effect 1', 'cleanUp 1','effect 2'])
+        expect(effects).toEqual(['effect 1', 'cleanUp 1'])
       }
     },
     {
       content: <div>removed</div>,
       test: () => {
         nextTick()
-        expect(effects).toEqual(['effect 1','cleanUp 1','effect 2','cleanUp 2','effect 3','cleanUp 3'])
+        expect(effects).toEqual(['effect 1','cleanUp 1'])
       }
     }
   ])
@@ -325,13 +325,15 @@ test('persist reference to any value', async () => {
     {
       content,
       test: ([p]) => {
+        nextTick()
         expect(p.textContent).toBe('x')
       }
     },
     {
       content,
       test: ([p]) => {
-        expect(p.textContent).toBe('xx')
+        nextTick()
+        expect(p.textContent).toBe('x')
       }
     }
   ])
@@ -445,7 +447,7 @@ test('async state update', async (done) => {
       content,
       test: ([button]) => {
         expect(+button.textContent).toBe(3) // all 3 state updates applied
-        expect(updates).toBe(5) // but component only renders once || why?
+        expect(updates).toBe(3)
         done()
       }
     }


### PR DESCRIPTION
This is a framework-level implementation of `React.memo`, which is built into the fre core, just like Vue, for accurate update.
With this, every component is `pureComponent,` and no additional API.
For example:
```js
function App () {
  const [state, setState] = useState(0)
  const [count, setCount] = useState(0)
  return (
    <div>
      {state}
      <A count={count}/>
      <button onClick={() => setState(state+1)}>+</button>
    </div>
  )
}

function A(props){
  console.log(222)
  return <div>{props.count}</div>
}
```
Component `<A/>` will not rerender, because the props count is not changed.

It needs to be explained the difference between `useMemo`

`useMemo` is to prevent repeated execution and generation of hooks, This pr is to prevent the repeated rendering of children components.


This is an important update. As the rendering of subcomponents is reduced, the test will be broken.
Let's have a try~
